### PR TITLE
Initial list of images from directory is shuffled so images in the sa...

### DIFF
--- a/elo.py
+++ b/elo.py
@@ -8,24 +8,63 @@ class TrueSkillRanking:
         self.counts = {}
         self.upvotes = {}
         self.downvotes = {}
+        self.comparison_history = []
 
     def get_rating(self, player):
         return self.ratings.get(player, Rating(mu=self.mu, sigma=self.sigma))
 
-    def update_rating(self, winner, loser):
-        winner_rating = self.get_rating(winner)
-        loser_rating = self.get_rating(loser)
+    def update_rating(self, comparisons):
+        if isinstance(comparisons, tuple):
+            comparisons = {comparisons}
 
-        new_winner_rating, new_loser_rating = rate_1vs1(winner_rating, loser_rating)
+        for winner, loser in comparisons:
+            winner_rating = self.get_rating(winner)
+            loser_rating = self.get_rating(loser)
 
-        self.ratings[winner] = new_winner_rating
-        self.ratings[loser] = new_loser_rating
+            new_winner_rating, new_loser_rating = rate_1vs1(winner_rating, loser_rating)
 
-        self.counts[winner] = self.counts.get(winner, 0) + 1
-        self.counts[loser] = self.counts.get(loser, 0) + 1
+            self.ratings[winner] = new_winner_rating
+            self.ratings[loser] = new_loser_rating
 
-        self.upvotes[winner] = self.upvotes.get(winner, 0) + 1
-        self.downvotes[loser] = self.downvotes.get(loser, 0) + 1
+            self.counts[winner] = self.counts.get(winner, 0) + 1
+            self.counts[loser] = self.counts.get(loser, 0) + 1
+
+            self.upvotes[winner] = self.upvotes.get(winner, 0) + 1
+            self.downvotes[loser] = self.downvotes.get(loser, 0) + 1
+
+        self.comparison_history.extend(comparisons)        
+        
+    def recalculate_rankings(self):
+        self.ratings = {}
+        self.counts = {}
+        self.upvotes = {}
+        self.downvotes = {}
+
+        comparisons_to_process = self.comparison_history[:]
+        self.comparison_history = []
+
+        for winner, loser in comparisons_to_process:
+            if winner is None:  # Remove loser from ratings when winner is None
+                if loser in self.ratings:
+                    del self.ratings[loser]
+                if loser in self.counts:
+                    del self.counts[loser]
+                if loser in self.upvotes:
+                    del self.upvotes[loser]
+                if loser in self.downvotes:
+                    del self.downvotes[loser]
+                self.comparison_history.append((winner, loser))
+            else:
+                self.update_rating((winner, loser))
+            
+    def remove_image(self, images):
+        if isinstance(images, str):
+            images_to_remove = {images}
+        else:
+            images_to_remove = set(images)
+        self.comparison_history = [(winner, loser) for winner, loser in self.comparison_history if not (winner is not None and (winner in images_to_remove or loser in images_to_remove))]
+        self.comparison_history.extend([(None, img) for img in images_to_remove])  # Add the removed images to the comparison history
+        self.recalculate_rankings()
 
     def get_rankings(self):
         return sorted(self.ratings.items(), key=lambda x: x[1].mu, reverse=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,8 +15,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8803344579810006"
-        crossorigin="anonymous"></script>
-    </head>
+    crossorigin="anonymous"></script>
+</head>
 <body>
     <div class="container">
         <audio id="clickSound" src="{{ url_for('static', filename='click.mp3') }}" preload="auto"></audio>
@@ -36,6 +36,8 @@
             <div class="buttons">
                 <button id="image1-btn" onclick="selectWinner('image1')">Image A is better <span class="shortcut">(Press 1 or left arrow)</span></button>
                 <button id="image2-btn" onclick="selectWinner('image2')">Image B is better <span class="shortcut">(Press 2 or right arrow)</span></button>
+                <button id="remove-image1-btn" onclick="removeImage(currentImages['image1'])">Remove Image A</button>
+                <button id="remove-image2-btn" onclick="removeImage(currentImages['image2'])">Remove Image B</button>
             </div>
         </div>
         <div class="rankings">
@@ -47,13 +49,39 @@
             Select Local Directory
         </button>
         <div class="right-buttons">
+            <button id="export-comparisons-btn" class="export-comparisons-btn">
+                <span class="material-icons">save</span>
+                Export Comparisons
+            </button>
+            <button id="import-comparison-history-btn" class="import-comparison-history-btn">
+                <span class="material-icons">upload</span>
+                Import Comparisons
+            </button>
             <button id="exportRankingsBtn" class="export-rankings-btn">
                 <span class="material-icons">save</span>
                 Export Rankings
             </button>
+            <button id="smartShuffleBtn" class="smart-shuffle-btn">
+                <span class="material-icons">shuffle</span>
+                Smart Shuffle
+            </button>
+            <label class="auto-shuffle-label">
+                <input type="checkbox" id="autoShuffleToggle">
+                Auto Shuffle Every 3 Comparisons
+            </label>
+            <div class="social-buttons">
+                <a href="https://github.com/QuentinWach/image-ranker" target="_blank" rel="noopener noreferrer" class="social-button github-button">
+                    <span class="material-icons">star</span>
+                    Star on GitHub
+                </a>
+                <a href="https://twitter.com/intent/tweet?text=Check%20out%20this%20awesome%20Image%20Ranker%20project!%20https://github.com/QuentinWach/image-ranker" target="_blank" rel="noopener noreferrer" class="social-button twitter-button">
+                    <span class="material-icons">share</span>
+                    Share on X
+                </a>
+            </div>
         </div>
     </div>
-
+    
     <footer class="footer">
         <div class="footer-content">
             <div class="footer-section">
@@ -84,38 +112,38 @@
             <p>&copy; 2024 Image Ranker. Made by <a href="https://x.com/QuentinWach" target="_blank">Quentin Wach</a>.</p>
         </div>
     </footer>
-
+    
     <script>
         let currentImages = {};
-
+        let max_display = 25;
         function loadImages() {
             fetch('/get_images')
-                .then(response => response.json())
-                .then(data => {
-                    if (data.error) {
-                        alert(data.error);
-                        return;
-                    }
-                    console.log('Received image data:', data);
-                    currentImages = data;
-                    document.getElementById('image1').src = data.image1;
-                    document.getElementById('image2').src = data.image2;
-                    console.log('Image1 src:', data.image1);
-                    console.log('Image2 src:', data.image2);
-                    document.getElementById('image1-name').textContent = `Image A: ${decodeURIComponent(data.image1.split('=').pop().split('/').pop())}`;
-                    document.getElementById('image2-name').textContent = `Image B: ${decodeURIComponent(data.image2.split('=').pop().split('/').pop())}`;
-                    updateProgress(data.progress);
-                })
-                .catch(error => {
-                    console.error('Error loading images:', error);
-                });
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    alert(data.error);
+                    return;
+                }
+                console.log('Received image data:', data);
+                currentImages = data;
+                document.getElementById('image1').src = '/serve_image?path=' +  data.image1;
+                document.getElementById('image2').src = '/serve_image?path=' + data.image2;
+                console.log('Image1 src:', data.image1);
+                console.log('Image2 src:', data.image2);
+                document.getElementById('image1-name').textContent = `Image A: ${decodeURIComponent(data.image1.split('=').pop().split('/').pop())}`;
+                document.getElementById('image2-name').textContent = `Image B: ${decodeURIComponent(data.image2.split('=').pop().split('/').pop())}`;
+                updateProgress(data.progress);
+            })
+            .catch(error => {
+                console.error('Error loading images:', error);
+            });
         }
-
+        
         function selectWinner(winnerImage) {
             playClickSound();
             const winner = currentImages[winnerImage];
             const loser = winnerImage === 'image1' ? currentImages.image2 : currentImages.image1;
-
+            
             fetch('/update_elo', {
                 method: 'POST',
                 headers: {
@@ -123,24 +151,54 @@
                 },
                 body: JSON.stringify({ winner, loser }),
             })
+            .then(() => {
+                updateRankings();
+                checkAutoShuffle();
+                loadImages();
+            });
+        }
+        
+        function removeImage(img_path) {
+            const confirmation = confirm(`Are you sure you want to remove ${img_path.split('/').pop()}? This will remove all remaining pairs that include this image.`);
+            if (!confirmation) return;
+            if (!img_path) {
+                console.error(`Image ${img_path} not found`);
+                return;
+            }
+            if (confirmation) {
+                console.error("fetching")
+                fetch('/remove_image', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ del_img: img_path }),
+                })
                 .then(() => {
                     loadImages();
                     updateRankings();
+                })
+                .catch(error => {
+                    console.error('Error removing image:', error);
                 });
+            }
         }
-
+        
         function updateRankings() {
+            display_count = 0
             fetch('/get_rankings')
-                .then(response => response.json())
-                .then(data => {
-                    const rankingsList = document.getElementById('rankingsList');
-                    rankingsList.innerHTML = '';
-                    data.forEach((item, index) => {
-                        const li = document.createElement('li');
-                        li.innerHTML = `
+            .then(response => response.json())
+            .then(data => {
+                const rankingsList = document.getElementById('rankingsList');
+                rankingsList.innerHTML = '';
+                data.forEach((item, index) => {
+                    display_count+=1
+                    const li = document.createElement('li');
+                    let imgUrl = display_count > max_display? "" : '/serve_image?path=' + item.image;
+                    li.innerHTML = `
                             <span class="rank">#${index + 1}</span>
                             <div class="image-container">
-                                <img src="${item.image}" alt="Ranked image" class="ranking-image">
+                                <img src="${imgUrl}" alt="Ranked image" class="ranking-image">
                                 <div class="image-hover"></div>
                             </div>
                             <span class="image-name">${item.image.split('/').pop()}</span>
@@ -150,14 +208,15 @@
                                 <span class="up-arrow"><i class="material-icons">arrow_upward</i>${item.upvotes}</span>
                                 <span class="down-arrow"><i class="material-icons">arrow_downward</i>${item.downvotes}</span>
                             </span>
+            <span class="remove-image-btn" onclick="removeImage('${item.image}')">Remove Image</span>
                         `;
-                        rankingsList.appendChild(li);
-
-                        // Add Google Ad after every 10th image
-                        if ((index + 1) % 10 === 0 && index !== data.length - 1) {
-                            const adLi = document.createElement('li');
-                            adLi.className = 'ad-container';
-                            adLi.innerHTML = `
+                    rankingsList.appendChild(li);
+                    
+                    // Add Google Ad after every 10th image
+                    if ((index + 1) % 10 === 0 && index !== data.length - 1) {
+                        const adLi = document.createElement('li');
+                        adLi.className = 'ad-container';
+                        adLi.innerHTML = `
                                 <ins class="adsbygoogle"
                                     style="display:block"
                                     data-ad-format="fluid"
@@ -165,37 +224,37 @@
                                     data-ad-client="ca-pub-8803344579810006"
                                     data-ad-slot="4041607466"></ins>
                             `;
-                            rankingsList.appendChild(adLi);
-
-                            // Push the ad to Google
-                            if (typeof adsbygoogle !== 'undefined' && adsbygoogle.loaded === false) {
-                                (adsbygoogle = window.adsbygoogle || []).push({});
-                            }
+                        rankingsList.appendChild(adLi);
+                        
+                        // Push the ad to Google
+                        if (typeof adsbygoogle !== 'undefined' && adsbygoogle.loaded === false) {
+                            (adsbygoogle = window.adsbygoogle || []).push({});
                         }
-                    });
-
-                    // Add event listeners for hover effect
-                    document.querySelectorAll('.image-container').forEach(container => {
-                        const img = container.querySelector('.ranking-image');
-                        const hoverDiv = container.querySelector('.image-hover');
-
-                        img.addEventListener('mouseenter', () => {
-                            hoverDiv.style.backgroundImage = `url(${img.src})`;
-                            hoverDiv.style.display = 'block';
-                        });
-
-                        img.addEventListener('mouseleave', () => {
-                            hoverDiv.style.display = 'none';
-                        });
-                    });
-
-                    // Ensure ads are loaded after the DOM is updated
-                    setTimeout(() => {
-                        (adsbygoogle = window.adsbygoogle || []).push({});
-                    }, 100);
+                    }
                 });
+                
+                // Add event listeners for hover effect
+                document.querySelectorAll('.image-container').forEach(container => {
+                    const img = container.querySelector('.ranking-image');
+                    const hoverDiv = container.querySelector('.image-hover');
+                    
+                    img.addEventListener('mouseenter', () => {
+                        hoverDiv.style.backgroundImage = `url(${img.src})`;
+                        hoverDiv.style.display = 'block';
+                    });
+                    
+                    img.addEventListener('mouseleave', () => {
+                        hoverDiv.style.display = 'none';
+                    });
+                });
+                
+                // Ensure ads are loaded after the DOM is updated
+                setTimeout(() => {
+                    (adsbygoogle = window.adsbygoogle || []).push({});
+                }, 100);
+            });
         }
-
+        
         function updateProgress(progress) {
             const progressFill = document.getElementById('progress-fill');
             const progressText = document.getElementById('progress-text');
@@ -203,10 +262,10 @@
             progressFill.style.width = `${percentage}%`;
             progressText.textContent = `Progress: ${progress.current} / ${progress.total} comparisons`;
         }
-
+        
         loadImages();
         updateRankings();
-
+        
         document.getElementById('selectDirectoryBtn').addEventListener('click', function() {
             fetch('/select_directory', {
                 method: 'POST'
@@ -235,43 +294,103 @@
                 alert('An error occurred while selecting the directory: ' + (error.message || error));
             });
         });
-
+        
         document.getElementById('exportRankingsBtn').addEventListener('click', function() {
             fetch('/export_rankings')
-                .then(response => {
-                    console.log('Response status:', response.status);
-                    console.log('Response headers:', response.headers);
-                    if (!response.ok) {
-                        return response.text().then(text => {
-                            throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
-                        });
-                    }
-                    return response.blob();
-                })
-                .then(blob => {
-                    console.log('Blob received:', blob);
-                    const url = window.URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.style.display = 'none';
-                    a.href = url;
-                    a.download = 'image_rankings.csv';
-                    document.body.appendChild(a);
-                    a.click();
-                    window.URL.revokeObjectURL(url);
-                    document.body.removeChild(a);
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    alert('An error occurred while exporting rankings: ' + error.message);
-                });
+            .then(response => {
+                console.log('Response status:', response.status);
+                console.log('Response headers:', response.headers);
+                if (!response.ok) {
+                    return response.text().then(text => {
+                        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+                    });
+                }
+                return response.blob();
+            })
+            .then(blob => {
+                console.log('Blob received:', blob);
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.style.display = 'none';
+                a.href = url;
+                a.download = 'image_rankings.csv';
+                document.body.appendChild(a);
+                a.click();
+                window.URL.revokeObjectURL(url);
+                document.body.removeChild(a);
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while exporting rankings: ' + error.message);
+            });
         });
-
+        
+        document.getElementById('export-comparisons-btn').addEventListener('click', function() {
+            fetch('/export_comparisons')
+            .then(response => {
+                console.log('Response status:', response.status);
+                console.log('Response headers:', response.headers);
+                if (!response.ok) {
+                    return response.text().then(text => {
+                        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+                    });
+                }
+                return response.blob();
+            })
+            .then(blob => {
+                console.log('Blob received:', blob);
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.style.display = 'none';
+                a.href = url;
+                a.download = 'comparisons.csv';
+                document.body.appendChild(a);
+                a.click();
+                window.URL.revokeObjectURL(url);
+                document.body.removeChild(a);
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while exporting comparisons: ' + error.message);
+            });
+        });
+        
+        document.getElementById('import-comparison-history-btn').addEventListener('click', function() {
+            const fileInput = document.createElement('input');
+            fileInput.type = 'file';
+            fileInput.accept = 'text/csv';
+            fileInput.addEventListener('change', function() {
+                const file = fileInput.files[0];
+                const formData = new FormData();
+                formData.append('file', file);
+                
+                const append = confirm("Do you want to append the imported history to the existing comparison history? If not, the existing history will be replaced.");
+                formData.append('append', append);
+                
+                fetch('/import_comparison_history', {
+                    method: 'POST',
+                    body: formData
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        alert('Comparison history imported successfully!');
+                        updateRankings(); // Update the ranking display
+                        loadImages(); // Update the progress display
+                    } else {
+                        alert('Error importing comparison history!');
+                    }
+                });
+            });
+            fileInput.click();
+        });
+        
         function playClickSound() {
             const clickSound = document.getElementById('clickSound');
             clickSound.currentTime = 0;
             clickSound.play();
         }
-
+        
         function animateButton(buttonId) {
             const button = document.getElementById(buttonId);
             button.classList.add('pressed');
@@ -279,7 +398,7 @@
                 button.classList.remove('pressed');
             }, 100);
         }
-
+        
         document.addEventListener('keydown', function(event) {
             if (event.key === '1' || event.key === 'ArrowLeft') {
                 selectWinner('image1');
@@ -289,6 +408,48 @@
                 animateButton('image2-btn');
             }
         });
+        
+        document.getElementById('smartShuffleBtn').addEventListener('click', function() {
+            fetch('/smart_shuffle')
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert('Smart shuffle applied successfully!');
+                    loadImages();
+                } else {
+                    alert('Error applying smart shuffle: ' + data.error);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while applying smart shuffle: ' + error.message);
+            });
+        });
+        
+        const autoShuffleToggle = document.getElementById('autoShuffleToggle');
+        let comparisonCount = 0;
+        
+        async function checkAutoShuffle() {
+            if (autoShuffleToggle.checked) {
+                comparisonCount++;
+                if (comparisonCount >= 3) {
+                    comparisonCount = 0;
+                    try {
+                        const response = await fetch('/smart_shuffle');
+                        const data = await response.json();
+                        if (data.success) {
+                            console.log('Auto smart shuffle applied successfully!');
+                            current_pair_index = 0;  // Set current_pair_index to 0 after shuffle
+                        } else {
+                            console.error('Error applying auto smart shuffle:', data.error);
+                        }
+                    } catch (error) {
+                        console.error('Error applying auto smart shuffle:', error.message);
+                    }
+                }
+            }
+        }
+        
     </script>
 </body>
 </html>


### PR DESCRIPTION
…me folder aren't all paired together.
Added a shuffle function that puts pairs of images with smaller rating differences and lower comparison counts earlier in the list to try and skip pointless matchups. Added remove image, goes back and recalculates rankings as if removed image didn't exist so that other images can't get free wins from a non-existant image. Added export/import completed comparisons and image deletions for resuming later on if a large image set isn't fully compared. Changed file path formatting so file paths only contain "/serve_image" where necessary. Limited number of images to display in ranking list to 25. Added button to ranking list to remove images from there.