### PR TITLE
[Feature]: Add revert functionality for last comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ image_pairs = []
 skipped_pairs = set()
 current_pair_index = 0
 last_shown_image = None
+current_displayed_pair = None
 context_data = None
 SUPPORTED_IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.jfif', '.avif', '.heic', '.heif')
 directory_status = {
@@ -213,13 +214,16 @@ def load_skipped_pairs_from_autosave(autosave_file):
 
 
 def reset_ranking_session(load_context=False):
-    global elo_ranking, excluded_images, image_pairs, skipped_pairs, current_pair_index, comparisons_since_autosave, context_data
+    global elo_ranking, excluded_images, image_pairs, skipped_pairs, current_pair_index
+    global comparisons_since_autosave, context_data, last_shown_image, current_displayed_pair
 
     elo_ranking = TrueSkillRanking()
     excluded_images = {}
     image_pairs = []
     skipped_pairs = set()
     current_pair_index = 0
+    last_shown_image = None
+    current_displayed_pair = None
     comparisons_since_autosave = 0
     if not load_context:
         context_data = None
@@ -403,13 +407,14 @@ def sort_browse_folders(folders, sort_mode):
     return sorted(folders, key=get_browse_folder_sort_key)
 
 def initialize_image_pairs(a=False):
-    global image_pairs, current_pair_index
+    global image_pairs, current_pair_index, current_displayed_pair
     image_paths, _ = get_image_paths(IMAGE_FOLDER)
     update_directory_status(len(image_paths))
     
     if len(image_paths) < 2:
         image_pairs = []
         current_pair_index = 0
+        current_displayed_pair = None
         return
 
     random.shuffle(image_paths)
@@ -442,6 +447,27 @@ def initialize_image_pairs(a=False):
     
     random.shuffle(image_pairs[n:])
     current_pair_index = 0
+    current_displayed_pair = None
+
+
+def requeue_pair_for_reranking(pair):
+    global image_pairs, current_pair_index, current_displayed_pair
+
+    target_index = max(current_pair_index - (1 if current_displayed_pair is not None else 0), 0)
+    target_pair = canonicalize_pair(pair)
+    rebuilt_pairs = []
+
+    for existing_pair in image_pairs:
+        if canonicalize_pair(existing_pair) == target_pair:
+            if len(rebuilt_pairs) < target_index:
+                target_index -= 1
+            continue
+        rebuilt_pairs.append(existing_pair)
+
+    rebuilt_pairs.insert(target_index, pair)
+    image_pairs = rebuilt_pairs
+    current_pair_index = target_index
+    current_displayed_pair = None
 
 
 def parse_comparison_history_rows(file):
@@ -548,6 +574,7 @@ def smart_shuffle_route():
 @app.route('/get_images')
 def get_images():
     global current_pair_index, last_shown_image, current_directory, image_pairs, directory_status
+    global current_displayed_pair
     if not current_directory:
         return jsonify({
             'state': 'no_directory',
@@ -564,6 +591,7 @@ def get_images():
 
     with image_pairs_lock:
         if current_pair_index >= len(image_pairs):
+            current_displayed_pair = None
             completed_pairs = len(elo_ranking.comparison_history)
             return jsonify({
                 'state': 'completed',
@@ -574,13 +602,15 @@ def get_images():
                 }
             })
         
-        img1, img2 = image_pairs[current_pair_index]
+        queued_pair = image_pairs[current_pair_index]
+        img1, img2 = queued_pair
         if last_shown_image is not None:
             if img1 == last_shown_image:
                 img1, img2 = img2, img1
                 app.logger.debug(f"Swapped display order: {os.path.basename(img1)} vs {os.path.basename(img2)}")
             elif img2 == last_shown_image:
                 pass
+        current_displayed_pair = queued_pair
         last_shown_image = img1
         current_pair_index += 1
         completed_pairs = len(elo_ranking.comparison_history)
@@ -687,13 +717,14 @@ def autosave_rankings():
 
 @app.route('/update_elo', methods=['POST'])
 def update_elo():
-    global comparisons_since_autosave, current_pair_index
+    global comparisons_since_autosave, current_pair_index, current_displayed_pair
     data = request.json
     if not data or 'winner' not in data or 'loser' not in data:
         return jsonify({'error': 'Missing winner or loser in request'}), 400
     winner = data['winner']
     loser = data['loser']
     elo_ranking.update_rating((winner, loser))
+    current_displayed_pair = None
     if data.get('exclude_loser', False):
         excluded_images[loser] = 'excluded'
         # Recalculate image pairs
@@ -709,7 +740,7 @@ def update_elo():
 
 @app.route('/skip_pair', methods=['POST'])
 def skip_pair():
-    global current_pair_index, image_pairs, current_directory, skipped_pairs
+    global current_pair_index, image_pairs, current_directory, skipped_pairs, current_displayed_pair
     if not current_directory:
         return jsonify({'error': 'No directory selected'}), 400
 
@@ -719,6 +750,7 @@ def skip_pair():
             pair = image_pairs.pop(current_pair_index - 1)
             skipped_pairs.add(canonicalize_pair(pair))
             current_pair_index -= 1
+            current_displayed_pair = None
             app.logger.info(f"Skipped pair: {pair}")
             skipped = True
 
@@ -730,11 +762,33 @@ def skip_pair():
 
 @app.route('/remove_image', methods=['POST'])
 def remove_image():
+    global current_displayed_pair
     image = request.json['del_img']
     global image_pairs
     image_pairs = [(img1, img2) for img1, img2 in image_pairs if img1!= image and img2!= image]
     elo_ranking.remove_image(image)
+    current_displayed_pair = None
     return jsonify({'success': True})
+
+
+@app.route('/revert_last_comparison', methods=['POST'])
+def revert_last_comparison():
+    global comparisons_since_autosave, last_shown_image
+
+    if not current_directory:
+        return jsonify({'error': 'No directory selected'}), 400
+
+    with image_pairs_lock:
+        reverted_pair = elo_ranking.revert_last_comparison()
+        if reverted_pair is None:
+            return jsonify({'error': 'No ranking decision is available to revert.'}), 400
+
+        requeue_pair_for_reranking(reverted_pair)
+        last_shown_image = None
+
+    comparisons_since_autosave = 0
+    autosave_rankings()
+    return jsonify({'success': True, 'pair': list(reverted_pair)})
 
 @app.route('/get_rankings')
 def get_rankings():
@@ -913,21 +967,23 @@ def get_exclusion_reasons():
 
 @app.route('/exclude_image', methods=['POST'])
 def exclude_image():
-    global excluded_images
+    global excluded_images, current_displayed_pair
     data = request.json
     excluded_image = data['excluded_image']
     reason = data.get('reason', 'excluded')
     excluded_images[excluded_image] = reason
     # Recalculate image pairs
     initialize_image_pairs()
+    current_displayed_pair = None
     return jsonify({'success': True})
 
 @app.route('/clear_excluded_images', methods=['POST'])
 def clear_excluded_images():
-    global excluded_images
+    global excluded_images, current_displayed_pair
     excluded_images.clear()
     # Recalculate image pairs
     initialize_image_pairs()
+    current_displayed_pair = None
     return jsonify({'success': True})
 
 # Add a new route to get the current directory

--- a/app.py
+++ b/app.py
@@ -779,10 +779,18 @@ def revert_last_comparison():
         return jsonify({'error': 'No directory selected'}), 400
 
     with image_pairs_lock:
-        reverted_pair = elo_ranking.revert_last_comparison()
-        if reverted_pair is None:
+        revertable_pair = elo_ranking.get_last_revertable_comparison()
+        if revertable_pair is None:
             return jsonify({'error': 'No ranking decision is available to revert.'}), 400
 
+        canonical_pair = canonicalize_pair(revertable_pair)
+        if canonical_pair in skipped_pairs:
+            return jsonify({'error': 'The last ranking cannot be reverted because that pair is currently skipped.'}), 400
+
+        if any(image in excluded_images for image in revertable_pair):
+            return jsonify({'error': 'The last ranking cannot be reverted because one of its images is currently excluded.'}), 400
+
+        reverted_pair = elo_ranking.revert_last_comparison()
         requeue_pair_for_reranking(reverted_pair)
         last_shown_image = None
 

--- a/app.py
+++ b/app.py
@@ -762,12 +762,14 @@ def skip_pair():
 
 @app.route('/remove_image', methods=['POST'])
 def remove_image():
-    global current_displayed_pair
+    global current_displayed_pair, image_pairs
     image = request.json['del_img']
-    global image_pairs
-    image_pairs = [(img1, img2) for img1, img2 in image_pairs if img1!= image and img2!= image]
-    elo_ranking.remove_image(image)
-    current_displayed_pair = None
+
+    with image_pairs_lock:
+        image_pairs = [(img1, img2) for img1, img2 in image_pairs if img1 != image and img2 != image]
+        elo_ranking.remove_image(image)
+        current_displayed_pair = None
+
     return jsonify({'success': True})
 
 

--- a/elo.py
+++ b/elo.py
@@ -33,6 +33,18 @@ class TrueSkillRanking:
             self.downvotes[loser] = self.downvotes.get(loser, 0) + 1
 
         self.comparison_history.extend(comparisons)        
+
+    def revert_last_comparison(self):
+        for index in range(len(self.comparison_history) - 1, -1, -1):
+            winner, loser = self.comparison_history[index]
+            if winner is None:
+                continue
+
+            reverted_pair = self.comparison_history.pop(index)
+            self.recalculate_rankings()
+            return reverted_pair
+
+        return None
         
     def recalculate_rankings(self):
         self.ratings = {}

--- a/elo.py
+++ b/elo.py
@@ -36,13 +36,20 @@ class TrueSkillRanking:
 
     def revert_last_comparison(self):
         for index in range(len(self.comparison_history) - 1, -1, -1):
-            winner, loser = self.comparison_history[index]
+            winner, _loser = self.comparison_history[index]
             if winner is None:
                 continue
 
             reverted_pair = self.comparison_history.pop(index)
             self.recalculate_rankings()
             return reverted_pair
+
+        return None
+
+    def get_last_revertable_comparison(self):
+        for winner, loser in reversed(self.comparison_history):
+            if winner is not None:
+                return (winner, loser)
 
         return None
         

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,8 +93,8 @@
                     <span class="material-symbols-rounded">upload</span>
                     Select Local Directory
                 </button>
-                <button id="import-comparison-history-btn" class="major-icon-btn" title="Import comparisons.csv or comparisons_autosave_YYYY-MM-DD.csv. Use Select Local Directory to resume a full autosave session with exclusions.">
-                    <span class="material-symbols-rounded">history</span>
+                <button id="revert-last-comparison-btn" class="major-icon-btn" title="Revert the last ranking and show that pair again.">
+                    <span class="material-symbols-rounded">undo</span>
                 </button>
             </div>
         </div>
@@ -679,48 +679,26 @@
             });
         });
         
-        document.getElementById('import-comparison-history-btn').addEventListener('click', function() {
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.accept = '.csv,text/csv';
-            fileInput.addEventListener('change', function() {
-                const file = fileInput.files[0];
-                if (!file) {
-                    return;
+        document.getElementById('revert-last-comparison-btn').addEventListener('click', function() {
+            fetch('{{ url_for('revert_last_comparison') }}', {
+                method: 'POST'
+            })
+            .then(async (response) => {
+                const data = await response.json();
+                if (!response.ok || !data.success) {
+                    throw new Error(data.error || 'Unable to revert the last ranking.');
                 }
-                const formData = new FormData();
-                formData.append('file', file);
-                
-                const append = confirm("Do you want to append the imported history to the existing comparison history? If not, the existing history will be replaced.");
-                formData.append('append', append);
-                
-                fetch('{{ url_for('import_comparison_history') }}', {
-                    method: 'POST',
-                    body: formData
-                })
-                .then(response => {
-                    return response.json().then(data => {
-                        if (!response.ok) {
-                            throw new Error(data.error || 'Error importing comparison history.');
-                        }
-                        return data;
-                    });
-                })
-                .then(data => {
-                    if (data.success) {
-                        alert('Comparison history imported successfully!');
-                        updateRankings(); // Update the ranking display
-                        loadImages(); // Update the progress display
-                    } else {
-                        alert(data.error || 'Error importing comparison history!');
-                    }
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    alert(error.message);
-                });
+                return data;
+            })
+            .then(() => {
+                setComparisonStatus('Last ranking reverted. Re-rank the restored pair when ready.', 'info');
+                updateRankings();
+                loadImages();
+            })
+            .catch((error) => {
+                console.error('Error reverting last comparison:', error);
+                setComparisonStatus(error.message, 'warning');
             });
-            fileInput.click();
         });
         
         function playClickSound() {

--- a/tests/test_resume_autosave.py
+++ b/tests/test_resume_autosave.py
@@ -302,6 +302,64 @@ class ResumeAutosaveTest(unittest.TestCase):
         )
         self.assertEqual(len(image_ranker_app.elo_ranking.comparison_history), 0)
 
+    def test_revert_last_comparison_rejects_excluded_images_without_mutating_history(self):
+        self.client.post(
+            "/set_directory",
+            data={"path": "dataset"},
+        )
+
+        first_pair = self.client.get("/get_images").get_json()
+        self.client.post(
+            "/update_elo",
+            json={
+                "winner": first_pair["image1"],
+                "loser": first_pair["image2"],
+            },
+        )
+
+        image_ranker_app.excluded_images[first_pair["image2"]] = "excluded"
+        rankings_before = image_ranker_app.elo_ranking.get_rankings()
+
+        response = self.client.post("/revert_last_comparison")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("currently excluded", response.get_json()["error"])
+        self.assertEqual(
+            image_ranker_app.elo_ranking.comparison_history,
+            [(first_pair["image1"], first_pair["image2"])],
+        )
+        self.assertEqual(image_ranker_app.elo_ranking.get_rankings(), rankings_before)
+
+    def test_revert_last_comparison_rejects_skipped_pairs_without_mutating_history(self):
+        self.client.post(
+            "/set_directory",
+            data={"path": "dataset"},
+        )
+
+        first_pair = self.client.get("/get_images").get_json()
+        self.client.post(
+            "/update_elo",
+            json={
+                "winner": first_pair["image1"],
+                "loser": first_pair["image2"],
+            },
+        )
+
+        image_ranker_app.skipped_pairs.add(
+            image_ranker_app.canonicalize_pair((first_pair["image1"], first_pair["image2"]))
+        )
+        rankings_before = image_ranker_app.elo_ranking.get_rankings()
+
+        response = self.client.post("/revert_last_comparison")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("currently skipped", response.get_json()["error"])
+        self.assertEqual(
+            image_ranker_app.elo_ranking.comparison_history,
+            [(first_pair["image1"], first_pair["image2"])],
+        )
+        self.assertEqual(image_ranker_app.elo_ranking.get_rankings(), rankings_before)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resume_autosave.py
+++ b/tests/test_resume_autosave.py
@@ -48,6 +48,7 @@ class ResumeAutosaveTest(unittest.TestCase):
         image_ranker_app.skipped_pairs = set()
         image_ranker_app.current_pair_index = 0
         image_ranker_app.last_shown_image = None
+        image_ranker_app.current_displayed_pair = None
         image_ranker_app.context_data = None
         image_ranker_app.comparisons_since_autosave = 0
         self.client = image_ranker_app.app.test_client()
@@ -225,6 +226,81 @@ class ResumeAutosaveTest(unittest.TestCase):
             image_ranker_app.canonicalize_pair(skipped_pair),
             {image_ranker_app.canonicalize_pair(pair) for pair in image_ranker_app.image_pairs},
         )
+
+    def test_revert_last_comparison_restores_previous_pair(self):
+        self.client.post(
+            "/set_directory",
+            data={"path": "dataset"},
+        )
+
+        first_pair_response = self.client.get("/get_images")
+        first_pair = first_pair_response.get_json()
+
+        self.client.post(
+            "/update_elo",
+            json={
+                "winner": first_pair["image1"],
+                "loser": first_pair["image2"],
+            },
+        )
+
+        self.client.get("/get_images")
+
+        response = self.client.post("/revert_last_comparison")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["success"])
+        self.assertEqual(len(image_ranker_app.elo_ranking.comparison_history), 0)
+
+        restored_pair_response = self.client.get("/get_images")
+        restored_pair = restored_pair_response.get_json()
+        self.assertEqual(
+            image_ranker_app.canonicalize_pair((restored_pair["image1"], restored_pair["image2"])),
+            image_ranker_app.canonicalize_pair((first_pair["image1"], first_pair["image2"])),
+        )
+
+    def test_revert_last_comparison_can_walk_back_multiple_rankings(self):
+        self.client.post(
+            "/set_directory",
+            data={"path": "dataset"},
+        )
+
+        first_pair = self.client.get("/get_images").get_json()
+        self.client.post(
+            "/update_elo",
+            json={
+                "winner": first_pair["image1"],
+                "loser": first_pair["image2"],
+            },
+        )
+
+        second_pair = self.client.get("/get_images").get_json()
+        self.client.post(
+            "/update_elo",
+            json={
+                "winner": second_pair["image1"],
+                "loser": second_pair["image2"],
+            },
+        )
+
+        self.client.get("/get_images")
+
+        first_revert = self.client.post("/revert_last_comparison")
+        self.assertEqual(first_revert.status_code, 200)
+        restored_second_pair = self.client.get("/get_images").get_json()
+        self.assertEqual(
+            image_ranker_app.canonicalize_pair((restored_second_pair["image1"], restored_second_pair["image2"])),
+            image_ranker_app.canonicalize_pair((second_pair["image1"], second_pair["image2"])),
+        )
+
+        second_revert = self.client.post("/revert_last_comparison")
+        self.assertEqual(second_revert.status_code, 200)
+        restored_first_pair = self.client.get("/get_images").get_json()
+        self.assertEqual(
+            image_ranker_app.canonicalize_pair((restored_first_pair["image1"], restored_first_pair["image2"])),
+            image_ranker_app.canonicalize_pair((first_pair["image1"], first_pair["image2"])),
+        )
+        self.assertEqual(len(image_ranker_app.elo_ranking.comparison_history), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Implemented a new route to revert the last ranking decision, allowing users to restore the previous image pair for re-evaluation.
- Updated the ELO ranking logic to handle the reversion of comparisons and ensure the integrity of the ranking history.
- Enhanced the front-end to include a button for reverting the last comparison, with appropriate user feedback.
- Added tests to verify the correct restoration of previous pairs and the functionality of the revert feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Revert Last Comparison" action to undo the most recent ranking and re-queue that pair for re-evaluation.

* **Improvements**
  * Improved session state handling to avoid stale "currently displayed" comparisons after skips, removals, exclusions, or updates.
  * UI updated to provide a direct revert control and to refresh rankings/images after a successful revert.

* **Tests**
  * Added tests for single and multi-step reverts and for rejection when pairs are skipped or excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->